### PR TITLE
fix: realign model / entity related fields compilation with `KAMO1-GO1` spec

### DIFF
--- a/pkg/compile/compile_entities.go
+++ b/pkg/compile/compile_entities.go
@@ -191,7 +191,9 @@ func getRelatedGoFieldForEntityPrimaryID(config cfg.MorpheConfig, r *registry.Re
 
 	return godef.StructField{
 		Name: fieldName,
-		Type: fieldType,
+		Type: godef.GoTypePointer{
+			ValueType: fieldType,
+		},
 	}, nil
 }
 
@@ -210,10 +212,8 @@ func getRelatedGoFieldForEntity(relationName string, targetEntity yaml.Entity, r
 		fieldName += "s"
 		fieldType = godef.GoTypeArray{
 			IsSlice: true,
-			ValueType: godef.GoTypePointer{
-				ValueType: godef.GoTypeStruct{
-					Name: targetEntity.Name,
-				},
+			ValueType: godef.GoTypeStruct{
+				Name: targetEntity.Name,
 			},
 		}
 	default:

--- a/pkg/compile/compile_entities_test.go
+++ b/pkg/compile/compile_entities_test.go
@@ -805,7 +805,9 @@ func (suite *CompileEntitiesTestSuite) TestMorpheEntityToGoStructs_Related_ForOn
 
 	field02 := structFields0[2]
 	suite.Equal(field02.Name, "BasicParentID")
-	suite.Equal(field02.Type, godef.GoTypeUint)
+	suite.Equal(field02.Type, godef.GoTypePointer{
+		ValueType: godef.GoTypeUint,
+	})
 
 	field03 := structFields0[3]
 	suite.Equal(field03.Name, "BasicParent")
@@ -992,11 +994,9 @@ func (suite *CompileEntitiesTestSuite) TestMorpheEntityToGoStructs_Related_ForMa
 	suite.Equal(field03.Name, "BasicParents")
 	suite.Equal(field03.Type, godef.GoTypeArray{
 		IsSlice: true,
-		ValueType: godef.GoTypePointer{
-			ValueType: godef.GoTypeStruct{
-				PackagePath: "",
-				Name:        "BasicParent",
-			},
+		ValueType: godef.GoTypeStruct{
+			PackagePath: "",
+			Name:        "BasicParent",
 		},
 	})
 
@@ -1167,7 +1167,9 @@ func (suite *CompileEntitiesTestSuite) TestMorpheEntityToGoStructs_Related_HasOn
 
 	field02 := structFields0[2]
 	suite.Equal(field02.Name, "BasicID")
-	suite.Equal(field02.Type, godef.GoTypeUint)
+	suite.Equal(field02.Type, godef.GoTypePointer{
+		ValueType: godef.GoTypeUint,
+	})
 
 	field03 := structFields0[3]
 	suite.Equal(field03.Name, "Basic")
@@ -1354,11 +1356,9 @@ func (suite *CompileEntitiesTestSuite) TestMorpheEntityToGoStructs_Related_HasMa
 	suite.Equal(field03.Name, "Basics")
 	suite.Equal(field03.Type, godef.GoTypeArray{
 		IsSlice: true,
-		ValueType: godef.GoTypePointer{
-			ValueType: godef.GoTypeStruct{
-				PackagePath: "",
-				Name:        "Basic",
-			},
+		ValueType: godef.GoTypeStruct{
+			PackagePath: "",
+			Name:        "Basic",
 		},
 	})
 

--- a/pkg/compile/compile_models.go
+++ b/pkg/compile/compile_models.go
@@ -201,7 +201,9 @@ func getRelatedGoFieldForMorpheModelPrimaryID(relatedModelName string, relatedMo
 
 	return godef.StructField{
 		Name: idFieldName,
-		Type: idFieldType,
+		Type: godef.GoTypePointer{
+			ValueType: idFieldType,
+		},
 	}, nil
 }
 
@@ -219,10 +221,8 @@ func getRelatedGoFieldForMorpheModel(relatedModelName string, relationType strin
 		return godef.StructField{
 			Name: fieldName,
 			Type: godef.GoTypeArray{
-				IsSlice: true,
-				ValueType: godef.GoTypePointer{
-					ValueType: valueType,
-				},
+				IsSlice:   true,
+				ValueType: valueType,
 			},
 		}
 	}

--- a/pkg/compile/compile_models_test.go
+++ b/pkg/compile/compile_models_test.go
@@ -1151,7 +1151,9 @@ func (suite *CompileModelsTestSuite) TestMorpheModelToGoStructs_Related_ForOne()
 
 	structFields02 := structFields0[2]
 	suite.Equal(structFields02.Name, "BasicParentID")
-	suite.Equal(structFields02.Type, godef.GoTypeUint)
+	suite.Equal(structFields02.Type, godef.GoTypePointer{
+		ValueType: godef.GoTypeUint,
+	})
 
 	structFields03 := structFields0[3]
 	suite.Equal(structFields03.Name, "BasicParent")
@@ -1262,10 +1264,8 @@ func (suite *CompileModelsTestSuite) TestMorpheModelToGoStructs_Related_ForMany(
 	suite.Equal(structFields03.Name, "BasicParents")
 	suite.Equal(structFields03.Type, godef.GoTypeArray{
 		IsSlice: true,
-		ValueType: godef.GoTypePointer{
-			ValueType: godef.GoTypeStruct{
-				Name: "BasicParent",
-			},
+		ValueType: godef.GoTypeStruct{
+			Name: "BasicParent",
 		},
 	})
 	suite.Len(structFields03.Tags, 0)
@@ -1363,7 +1363,9 @@ func (suite *CompileModelsTestSuite) TestMorpheModelToGoStructs_Related_HasOne()
 
 	structFields02 := structFields0[2]
 	suite.Equal(structFields02.Name, "BasicID")
-	suite.Equal(structFields02.Type, godef.GoTypeUint)
+	suite.Equal(structFields02.Type, godef.GoTypePointer{
+		ValueType: godef.GoTypeUint,
+	})
 	suite.Len(structFields02.Tags, 0)
 
 	structFields03 := structFields0[3]
@@ -1477,10 +1479,8 @@ func (suite *CompileModelsTestSuite) TestMorpheModelToGoStructs_Related_HasMany(
 	suite.Equal(structFields03.Name, "Basics")
 	suite.Equal(structFields03.Type, godef.GoTypeArray{
 		IsSlice: true,
-		ValueType: godef.GoTypePointer{
-			ValueType: godef.GoTypeStruct{
-				Name: "Basic",
-			},
+		ValueType: godef.GoTypeStruct{
+			Name: "Basic",
 		},
 	})
 	suite.Len(structFields03.Tags, 0)

--- a/testdata/ground-truth/compile-minimal/entities/company.go
+++ b/testdata/ground-truth/compile-minimal/entities/company.go
@@ -5,7 +5,7 @@ type Company struct {
 	Name      string
 	TaxID     string
 	PersonIDs []uint
-	Persons   []*Person
+	Persons   []Person
 }
 
 func (e Company) GetIDPrimary() CompanyIDPrimary {

--- a/testdata/ground-truth/compile-minimal/entities/person.go
+++ b/testdata/ground-truth/compile-minimal/entities/person.go
@@ -9,7 +9,7 @@ type Person struct {
 	ID          uint
 	LastName    string
 	Nationality enums.Nationality
-	CompanyID   uint
+	CompanyID   *uint
 	Company     *Company
 }
 

--- a/testdata/ground-truth/compile-minimal/models/company.go
+++ b/testdata/ground-truth/compile-minimal/models/company.go
@@ -5,7 +5,7 @@ type Company struct {
 	Name      string
 	TaxID     string
 	PersonIDs []uint
-	Persons   []*Person
+	Persons   []Person
 }
 
 func (m Company) GetIDName() CompanyIDName {

--- a/testdata/ground-truth/compile-minimal/models/contact_info.go
+++ b/testdata/ground-truth/compile-minimal/models/contact_info.go
@@ -3,7 +3,7 @@ package models
 type ContactInfo struct {
 	Email    string
 	ID       uint `morphe:"mandatory"`
-	PersonID uint
+	PersonID *uint
 	Person   *Person
 }
 

--- a/testdata/ground-truth/compile-minimal/models/person.go
+++ b/testdata/ground-truth/compile-minimal/models/person.go
@@ -9,9 +9,9 @@ type Person struct {
 	ID            uint `morphe:"mandatory"`
 	LastName      string
 	Nationality   enums.Nationality
-	CompanyID     uint
+	CompanyID     *uint
 	Company       *Company
-	ContactInfoID uint
+	ContactInfoID *uint
 	ContactInfo   *ContactInfo
 }
 


### PR DESCRIPTION
Pointers for "one" cardinality fields (IDs, model / entity structs) are idiomatic in common frameworks in Go. Non-pointerized slices are also idiomatic for "many" cardinality fields. A nil check suffices for both optional field types.